### PR TITLE
Update to the latest xsbt-web-plugin (0.9 -> 1.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ Define the plugin as a dependency to your project by adding the following lines 
 
     resolvers += "sbt-vaadin-plugin repo" at "http://henrikerola.github.io/repository/releases"
 
-    addSbtPlugin("org.vaadin.sbt" % "sbt-vaadin-plugin" % "1.1.0")
+    addSbtPlugin("org.vaadin.sbt" % "sbt-vaadin-plugin" % "1.2.0")
     
 After that you need to enabled the plugin on the projects you want to use it. This is done by including settings from `vaadinSettings`, `vaadinAddOnSettings` or `vaadinWebSettings`:
 
  * `vaadinSettings` contains all settings and tasks provided by the plugin.
  * `vaadinAddOnSettings` is an extension to `vaadinSettings` and it's suitable for projects that produce a Vaadin add-on jar.
- * `vaadinWebSettings` contains settings from `vaadinSettings` and [xsbt-web-plugin](https://github.com/JamesEarlDouglas/xsbt-web-plugin)'s `webSettings`.
+ * `vaadinWebSettings` contains settings from `vaadinSettings` and setup of resource generators (themes and widgetsets).
 
 
 The plugin doesn't add any Vaadin dependencies, those must be added explicitly to the projects using the plugin.

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "sbt-vaadin-plugin"
 
 description := "Vaadin Plugin for sbt"
 
-version := "1.1.0"
+version := "1.2.0"
 
 organization := "org.vaadin.sbt"
 
@@ -21,12 +21,13 @@ vaadinSettings
 
 packageOptions in (Compile, packageBin) <+= org.vaadin.sbt.tasks.AddOnJarManifestTask.addOnJarManifestTask
 
-addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "0.9.0")
+//addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "0.9.0")
+addSbtPlugin("com.earldouglas" % "xsbt-web-plugin" % "1.0.0")
 
 ScriptedPlugin.scriptedSettings
 
 scriptedBufferLog := false
 
 scriptedLaunchOpts := { scriptedLaunchOpts.value ++
-  Seq("-Dplugin.version=" + version.value, "-Dvaadin.version=7.3.5")
+  Seq("-Dplugin.version=" + version.value, "-Dvaadin.version=7.4.0")
 }

--- a/src/main/scala/org/vaadin/sbt/VaadinPlugin.scala
+++ b/src/main/scala/org/vaadin/sbt/VaadinPlugin.scala
@@ -2,8 +2,6 @@ package org.vaadin.sbt
 
 import sbt._
 import sbt.Keys._
-//import com.earldouglas.xsbtwebplugin.WebPlugin.webSettings
-//import com.earldouglas.xsbtwebplugin.PluginKeys.webappResources
 import org.vaadin.sbt.tasks._
 
 object VaadinPlugin extends Plugin with VaadinKeys {
@@ -13,7 +11,9 @@ object VaadinPlugin extends Plugin with VaadinKeys {
     compileVaadinWidgetsets <<= CompileWidgetsetsTask.compileWidgetsetsTask,
     vaadinWidgetsets := Nil,
     enableCompileVaadinWidgetsets := true,
-    target in compileVaadinWidgetsets := (resourceManaged in Compile).value / "webapp" / "VAADIN" / "widgetsets",
+    // target in compileVaadinWidgetsets := (resourceManaged in Compile).value / "webapp" / "VAADIN" / "widgetsets",
+    // TODO: refactor to use a value from 'webappDest in webapp')
+    target in compileVaadinWidgetsets := (target in Compile).value / "webapp" / "VAADIN" / "widgetsets",
     vaadinOptions in compileVaadinWidgetsets := Nil,
     javaOptions in compileVaadinWidgetsets := Nil,
 
@@ -31,7 +31,9 @@ object VaadinPlugin extends Plugin with VaadinKeys {
     compileVaadinThemes <<= CompileThemesTask.compileThemesTask,
     vaadinThemes := Nil,
     vaadinThemesDir <<= sourceDirectory(sd => Seq(sd / "main" / "webapp" / "VAADIN" / "themes")),
-    target in compileVaadinThemes := (resourceManaged in Compile).value / "webapp" / "VAADIN" / "themes",
+    // target in compileVaadinThemes := (resourceManaged in Compile).value / "webapp" / "VAADIN" / "themes",
+    // TODO: refactor to use a value from 'webappDest in webapp')
+    target in compileVaadinThemes := (target in Compile).value / "webapp" / "VAADIN" / "themes",
 
     packageVaadinDirectoryZip <<= PackageDirectoryZipTask.packageDirectoryZipTask,
     // Include binary jar into the zip file.
@@ -56,13 +58,8 @@ object VaadinPlugin extends Plugin with VaadinKeys {
 
   val vaadinWebSettings = vaadinSettings /*++ webSettings*/ ++ Seq(
     resourceGenerators in Compile <+= CompileWidgetsetsTask.compileWidgetsetsInResourceGeneratorsTask,
-    resourceGenerators in Compile <+= compileVaadinThemes,
-    //    webappResources in Compile <+= (resourceManaged in Compile)(sd => sd / "webapp"), // Does not compile
-    // do not know how to replace the string above. to make everything work by default, adding the following
-    // rows works fine
-    // by default new xsbt webplugin does not pick it from the target directory
-    target in compileVaadinThemes := (sourceDirectory in Compile).value / "webapp" / "VAADIN" / "themes",
-    target in compileVaadinWidgetsets := (sourceDirectory in Compile).value / "webapp" / "VAADIN" / "widgetsets"
+    resourceGenerators in Compile <+= compileVaadinThemes
+  //    webappResources in Compile <+= (resourceManaged in Compile)(sd => sd / "webapp"), // Does not compile
   )
 
 }

--- a/src/main/scala/org/vaadin/sbt/VaadinPlugin.scala
+++ b/src/main/scala/org/vaadin/sbt/VaadinPlugin.scala
@@ -11,7 +11,6 @@ object VaadinPlugin extends Plugin with VaadinKeys {
     compileVaadinWidgetsets <<= CompileWidgetsetsTask.compileWidgetsetsTask,
     vaadinWidgetsets := Nil,
     enableCompileVaadinWidgetsets := true,
-    // target in compileVaadinWidgetsets := (resourceManaged in Compile).value / "webapp" / "VAADIN" / "widgetsets",
     // TODO: refactor to use a value from 'webappDest in webapp')
     target in compileVaadinWidgetsets := (target in Compile).value / "webapp" / "VAADIN" / "widgetsets",
     vaadinOptions in compileVaadinWidgetsets := Nil,
@@ -31,7 +30,6 @@ object VaadinPlugin extends Plugin with VaadinKeys {
     compileVaadinThemes <<= CompileThemesTask.compileThemesTask,
     vaadinThemes := Nil,
     vaadinThemesDir <<= sourceDirectory(sd => Seq(sd / "main" / "webapp" / "VAADIN" / "themes")),
-    // target in compileVaadinThemes := (resourceManaged in Compile).value / "webapp" / "VAADIN" / "themes",
     // TODO: refactor to use a value from 'webappDest in webapp')
     target in compileVaadinThemes := (target in Compile).value / "webapp" / "VAADIN" / "themes",
 
@@ -59,7 +57,6 @@ object VaadinPlugin extends Plugin with VaadinKeys {
   val vaadinWebSettings = vaadinSettings /*++ webSettings*/ ++ Seq(
     resourceGenerators in Compile <+= CompileWidgetsetsTask.compileWidgetsetsInResourceGeneratorsTask,
     resourceGenerators in Compile <+= compileVaadinThemes
-  //    webappResources in Compile <+= (resourceManaged in Compile)(sd => sd / "webapp"), // Does not compile
   )
 
 }

--- a/src/main/scala/org/vaadin/sbt/VaadinPlugin.scala
+++ b/src/main/scala/org/vaadin/sbt/VaadinPlugin.scala
@@ -2,8 +2,8 @@ package org.vaadin.sbt
 
 import sbt._
 import sbt.Keys._
-import com.earldouglas.xsbtwebplugin.WebPlugin.webSettings
-import com.earldouglas.xsbtwebplugin.PluginKeys.webappResources
+//import com.earldouglas.xsbtwebplugin.WebPlugin.webSettings
+//import com.earldouglas.xsbtwebplugin.PluginKeys.webappResources
 import org.vaadin.sbt.tasks._
 
 object VaadinPlugin extends Plugin with VaadinKeys {
@@ -54,10 +54,15 @@ object VaadinPlugin extends Plugin with VaadinKeys {
       }
   )
 
-  val vaadinWebSettings = vaadinSettings ++ webSettings ++ Seq(
+  val vaadinWebSettings = vaadinSettings /*++ webSettings*/ ++ Seq(
     resourceGenerators in Compile <+= CompileWidgetsetsTask.compileWidgetsetsInResourceGeneratorsTask,
     resourceGenerators in Compile <+= compileVaadinThemes,
-    webappResources in Compile <+= (resourceManaged in Compile)(sd => sd / "webapp")
+    //    webappResources in Compile <+= (resourceManaged in Compile)(sd => sd / "webapp"), // Does not compile
+    // do not know how to replace the string above. to make everything work by default, adding the following
+    // rows works fine
+    // by default new xsbt webplugin does not pick it from the target directory
+    target in compileVaadinThemes := (sourceDirectory in Compile).value / "webapp" / "VAADIN" / "themes",
+    target in compileVaadinWidgetsets := (sourceDirectory in Compile).value / "webapp" / "VAADIN" / "widgetsets"
   )
 
 }


### PR DESCRIPTION
Hi Henri,

Let me introduce an updated version of sbt-vaadin-plugin.

This pull request allows us to use the latest xsbt-web-plugin 1.0 with all of its new features. That is why the next minor version of sbt-vaadin-plugin (1.1 -> 1.2) was introduced. Readme file is also updated. 

Existing projects that depend on current version of sbt-vaadin-plugin 1.1 should be built without any problems.

Can you please verify the request, merge and publish if everything is fine.

Thank you,
Dmitry