### PR TITLE
Please look at my branch wl/fixed-gwt-cache-dir

### DIFF
--- a/src/main/scala/org/vaadin/sbt/tasks/CompileWidgetsetsTask.scala
+++ b/src/main/scala/org/vaadin/sbt/tasks/CompileWidgetsetsTask.scala
@@ -1,8 +1,8 @@
 package org.vaadin.sbt.tasks
 
-import _root_.java.io.{FileNotFoundException, IOException}
+import _root_.java.io.{ FileNotFoundException, IOException }
 
-import org.vaadin.sbt.VaadinPlugin.{compileVaadinWidgetsets, vaadinOptions, vaadinWidgetsets}
+import org.vaadin.sbt.VaadinPlugin.{ compileVaadinWidgetsets, vaadinOptions, vaadinWidgetsets }
 import org.vaadin.sbt.util.ForkUtil._
 import org.vaadin.sbt.util.ProjectUtil._
 import sbt.Keys._
@@ -86,9 +86,7 @@ object CompileWidgetsetsTask {
       } finally {
         log.debug(s"Deleting persistent unit cache dir ${tmpDir.absolutePath}")
         try {
-          if (!deleteRecursive(tmpDir)) {
-            log.warn(s"Deleting ${tmpDir.absolutePath} failed")
-          }
+          deleteRecursive(tmpDir)
         } catch {
           case e: IOException => log.warn(s"Deleting ${tmpDir.absolutePath} failed with msg ${e.getLocalizedMessage}")
         }
@@ -96,14 +94,16 @@ object CompileWidgetsetsTask {
     }
   }
 
-  private def deleteRecursive(path: File): Boolean = {
-    if (!path.exists()) throw new FileNotFoundException(path.getAbsolutePath)
-    var ret = true
-    if (path.isDirectory) {
-      for (f <- path.listFiles()) {
-        ret = ret && deleteRecursive(f)
-      }
+  private def deleteRecursive(path: File): Unit = {
+    if (!path.exists()) {
+      throw new FileNotFoundException(path.getAbsolutePath)
     }
-    ret && path.delete()
+
+    if (path.isDirectory) {
+      path.listFiles() foreach deleteRecursive
+    }
+    if (!path.delete()) {
+      throw new IOException(s"Could not delete ${path.absolutePath}")
+    }
   }
 }

--- a/src/main/scala/org/vaadin/sbt/tasks/CompileWidgetsetsTask.scala
+++ b/src/main/scala/org/vaadin/sbt/tasks/CompileWidgetsetsTask.scala
@@ -67,11 +67,11 @@ object CompileWidgetsetsTask {
 
       exitValue match {
         case Left(error) => sys.error(error)
-        case Right(widgetsets) => {
+        case Right(curWS) => {
           log.debug("Deleting %s" format target / "WEB-INF")
           IO.delete(target / "WEB-INF")
 
-          val generatedFiles: Seq[Seq[File]] = widgetsets map {
+          val generatedFiles: Seq[Seq[File]] = curWS map {
             widgetset => (target / widgetset ** ("*")).get
           }
 


### PR DESCRIPTION
Hi,
I use your plugin for our vaadin project, and I'm working on a linux system.
Here I found that you set the GWT unit cache dir to a temporary directory, which stays around. If you have a separate /tmp partition, this partition can then fill up with leftover temp directories.
I added code to automatically remove the temp dir for the "gwt unit cache dir" after each widget set compilation, to reduce the amount of leftover files.

I also experimented with a setting to configure the directory for the "gwt unit cache dir" (to maybe keep it for repeated GWT compilations) - this experiment is in the wl/allow-keep-unit-cache branch - but I could not get that code to compile (too many parameters for the widgetset compilation task?), so this branch is not usable yet (I appreciate your input on this branch...)

Cheers,
Wolfgang Liebich